### PR TITLE
Fix a bug in completion extraction

### DIFF
--- a/modeling.py
+++ b/modeling.py
@@ -215,7 +215,7 @@ class CausalModel(SeqToSeqModel):
             **kwargs,
         )
         batch_size, length = inputs.input_ids.shape
-        return self.tokenizer.decode(outputs[0, length:], skip_special_tokens=True)
+        return self.tokenizer.decode(outputs[0], skip_special_tokens=True).split(prompt, maxsplit=1)[-1]
 
     def get_choice(self, text: str, **kwargs) -> Tuple[float, float]:
         self.load()
@@ -282,7 +282,7 @@ class LlamaModel(SeqToSeqModel):
             **kwargs,
         )
         batch_size, length = inputs.input_ids.shape
-        return self.tokenizer.decode(outputs[0, length:], skip_special_tokens=True)
+        return self.tokenizer.decode(outputs[0], skip_special_tokens=True).split(text, maxsplit=1)[-1]
 
     def get_choice(self, text: str, **kwargs) -> Tuple[float, float]:
         self.load()


### PR DESCRIPTION
LLaMa tokens are not independent. They rely on tokens next to them to decode. If we only decode the tokens after the ending position of the prompts, the resulting completion is likely to be incorrect. 

This bug leads to constant wrong indentations in the first line of generated python codes on the HumanEval dataset, because one space is missing at the beginning.

Here is a minimal replication of the bug:

```python
space = tokenizer.decode([1678])
print('"' + space + '"')
count_leading_spaces(space)
```
"&nbsp;&nbsp;"
Leading spaces:  2

```python
token_return = tokenizer.decode([736])
print('"' + token_return + '"')
count_leading_spaces(token_return)
```
"return"
Leading spaces:  0

```python
space_and_right = tokenizer.decode([1678, 736])
print('"' + space_and_right + '"')
count_leading_spaces(space_and_right)
```
"&nbsp;&nbsp;&nbsp;return"
Leading spaces:  3

```python
space_and_left = tokenizer.decode([13, 1678])
print(repr(space_and_left))
count_leading_spaces(space_and_left.lstrip('\n'))
```
'\n&nbsp;&nbsp;&nbsp;'
Leading spaces:  3

Only when all tokens are present, the result is correct.

```python
full = tokenizer.decode([13, 1678, 736])
print(repr(full))
count_leading_spaces(full.lstrip('\n'))
```

'\n&nbsp;&nbsp;&nbsp;&nbsp;return'
Leading spaces:  4

See https://gist.github.com/Happylkx/3dcc8c22369aeb8991940fc05f0de2d5 for the full replication.